### PR TITLE
#245 CLI should not require text as an argument if -v or -help is pro…

### DIFF
--- a/src/main/java/com/aif/cli/Main.java
+++ b/src/main/java/com/aif/cli/Main.java
@@ -34,6 +34,9 @@ public class Main {
     }
 
     private static void commandLinePrecheck(final CommandLine commandLine) throws ParseException {
+        if (commandLine.getOptions().length == 0) {
+            throw new ParseException("Command key is not provided");
+        }
         if (commandLine.getOptions().length > 1) {
             throw new ParseException("There are too many options");
         }

--- a/src/main/java/com/aif/cli/Main.java
+++ b/src/main/java/com/aif/cli/Main.java
@@ -4,9 +4,6 @@ import com.aif.language.sentence.ICommand;
 import org.apache.commons.cli.*;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class Main {
 
@@ -16,8 +13,7 @@ public class Main {
             final CommandLine commandLine = Main.createCommandLineParser(options, args);
             commandLinePrecheck(commandLine);
             for (ICommand.Commands command : ICommand.Commands.values()) {
-                if (commandLine.hasOption(command.getCommandKey())) {
-                    command.getCommand().validate(commandLine.getArgs());
+                if (commandLine.hasOption(command.getCommandKey()) && command.getCommand().validate(commandLine.getArgs())) {
                     command.getCommand().apply(commandLine.getArgs());
                     return;
                 }
@@ -38,15 +34,8 @@ public class Main {
     }
 
     private static void commandLinePrecheck(final CommandLine commandLine) throws ParseException {
-        if (commandLine.getArgs().length == 0) {
-            throw new ParseException("There is no path");
-        }
-        if (commandLine.getArgs().length > 1) {
-            throw new ParseException("There are too many arguments");
-        }
-        final Path path = Paths.get(commandLine.getArgs()[0]);
-        if (!Files.exists(path)) {
-            throw new ParseException(String.format("Path: %s not exists", path));
+        if (commandLine.getOptions().length > 1) {
+            throw new ParseException("There are too many options");
         }
     }
 

--- a/src/main/java/com/aif/language/sentence/BasicTextCommand.java
+++ b/src/main/java/com/aif/language/sentence/BasicTextCommand.java
@@ -1,12 +1,24 @@
 package com.aif.language.sentence;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 abstract class BasicTextCommand implements ICommand {
 
     @Override
     public boolean validate(String... args) {
-        if (args.length != 0 ) {
+        if (args.length == 0 ) {
+            System.out.println("There is no path");
             return false;
         }
+
+        final Path path = Paths.get(args[0]);
+        if (!Files.exists(path)) {
+            System.out.printf("Path: %s not exists\n", path);
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
also:

- it does not allow more than single option (command)
- now the command validates arguments